### PR TITLE
Temporarily remove KeyUsage from createOnlyProperties to prevent key …

### DIFF
--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -88,9 +88,6 @@
   "primaryIdentifier": [
     "/properties/KeyId"
   ],
-  "createOnlyProperties": [
-    "/properties/KeyUsage"
-  ],
   "writeOnlyProperties": [
     "/properties/PendingWindowInDays"
   ],

--- a/key/docs/README.md
+++ b/key/docs/README.md
@@ -92,7 +92,7 @@ _Type_: String
 
 _Allowed Values_: <code>ENCRYPT_DECRYPT</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### PendingWindowInDays
 

--- a/key/docs/README.md
+++ b/key/docs/README.md
@@ -92,7 +92,7 @@ _Type_: String
 
 _Allowed Values_: <code>ENCRYPT_DECRYPT</code>
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### PendingWindowInDays
 


### PR DESCRIPTION
…re-creation

*Issue #, if available:*

N/A

*Description of changes:*

Temporarily remove KeyUsage from createOnlyProperties. This will prevent keys from being re-created when their templates are updated from an unspecified (default) KeyUsage to an explicitly specified default KeyUsage. Example: 

**Original Template:**
```
Resources:
  KeyResource:
    Type: AWS::KMS::Key
    Properties:
      KeyPolicy:
        Version: 2012-10-17
        Id: key-default
        Statement:
          - Sid: Enable IAM User Permissions
            Effect: Allow
            Principal:
              AWS: !Ref 'AWS::AccountId'
            Action: 'kms:*'
            Resource: '*'
Outputs:
  KeyId:
    Value: !Ref KeyResource
```

**Updated Template:**
```
Resources:
  KeyResource:
    Type: AWS::KMS::Key
    Properties:
      KeyUsage: ENCRYPT_DECRYPT
      KeyPolicy:
        Version: 2012-10-17
        Id: key-default
        Statement:
          - Sid: Enable IAM User Permissions
            Effect: Allow
            Principal:
              AWS: !Ref 'AWS::AccountId'
            Action: 'kms:*'
            Resource: '*'
Outputs:
  KeyId:
    Value: !Ref KeyResource
``` 

This fix is **temporary** and only works because there is only one valid KeyUsage value, A more permanent fix will be included with asymmetric support (#24).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
