### PR TITLE
Resolve duplicate tags

### DIFF
--- a/key/src/main/java/software/amazon/kms/key/Configuration.java
+++ b/key/src/main/java/software/amazon/kms/key/Configuration.java
@@ -24,6 +24,6 @@ class Configuration extends BaseConfiguration {
 
         return resourceModel.getTags()
             .stream()
-            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+            .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
     }
 }

--- a/key/src/test/java/software/amazon/kms/key/ConfigurationTest.java
+++ b/key/src/test/java/software/amazon/kms/key/ConfigurationTest.java
@@ -1,0 +1,28 @@
+package software.amazon.kms.key;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+class ConfigurationTest {
+
+    @Test
+    public void testMergeDuplicateKeys() {
+        final ResourceModel model = ResourceModel.builder()
+            .tags(ImmutableSet.of(new Tag("sameKey", "value1"), new Tag("sameKey", "value2")))
+            .build();
+
+        final Configuration configuration = new Configuration();
+
+        final Map<String, String> tags = configuration.resourceDefinedTags(model);
+
+        assertEquals(ImmutableMap.of("sameKey", "value2"), tags);
+
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR resolves the duplicate tags if same tags with different value. Previously, it will cause failure.

The resolve rule is that last tag wins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
