### PR TITLE
Add Eventual Consistency Propagation Delay to Alias Resource

### DIFF
--- a/alias/.rpdk-config
+++ b/alias/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::KMS::Alias",
     "language": "java",
     "runtime": "java8",
@@ -12,5 +13,6 @@
             "alias"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.kms.alias.HandlerWrapperExecutable"
 }

--- a/alias/src/main/java/software/amazon/kms/alias/BaseHandlerStd.java
+++ b/alias/src/main/java/software/amazon/kms/alias/BaseHandlerStd.java
@@ -7,53 +7,54 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>  {
-  protected static final int CALLBACK_DELAY_SECONDS = 60;
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    protected static final int CALLBACK_DELAY_SECONDS = 60;
 
-  final AliasHelper aliasHelper;
+    final AliasHelper aliasHelper;
 
-  public BaseHandlerStd() {
-    this(new AliasHelper());
-  }
-
-  public BaseHandlerStd(final AliasHelper aliasHelper) {
-    // Allows for mocking alias helper in our unit tests
-    this.aliasHelper = aliasHelper;
-  }
-
-  @Override
-  public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
-      final ResourceHandlerRequest<ResourceModel> request,
-      final CallbackContext callbackContext,
-      final Logger logger) {
-    return handleRequest(
-        proxy,
-        request,
-        callbackContext != null ? callbackContext : new CallbackContext(),
-        proxy.newProxy(ClientBuilder::getClient),
-        logger);
-  }
-
-  protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-      AmazonWebServicesClientProxy proxy,
-      ResourceHandlerRequest<ResourceModel> request,
-      CallbackContext callbackContext,
-      ProxyClient<KmsClient> proxyClient,
-      Logger logger);
-
-  /**
-   * Perform the final propagation delay to make sure the latest
-   * changes to the alias are available throughout the region.
-   */
-  protected static ProgressEvent<ResourceModel, CallbackContext> propagate(
-      final ProgressEvent<ResourceModel, CallbackContext> progressEvent) {
-    final CallbackContext callbackContext = progressEvent.getCallbackContext();
-    if (callbackContext.isPropagated()) {
-      return progressEvent;
+    public BaseHandlerStd() {
+        this(new AliasHelper());
     }
 
-    callbackContext.setPropagated(true);
-    return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS,
+    public BaseHandlerStd(final AliasHelper aliasHelper) {
+        // Allows for mocking alias helper in our unit tests
+        this.aliasHelper = aliasHelper;
+    }
+
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger) {
+        return handleRequest(
+            proxy,
+            request,
+            callbackContext != null ? callbackContext : new CallbackContext(),
+            proxy.newProxy(ClientBuilder::getClient),
+            logger);
+    }
+
+    protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        AmazonWebServicesClientProxy proxy,
+        ResourceHandlerRequest<ResourceModel> request,
+        CallbackContext callbackContext,
+        ProxyClient<KmsClient> proxyClient,
+        Logger logger);
+
+    /**
+     * Perform the final propagation delay to make sure the latest
+     * changes to the alias are available throughout the region.
+     */
+    protected static ProgressEvent<ResourceModel, CallbackContext> propagate(
+        final ProgressEvent<ResourceModel, CallbackContext> progressEvent) {
+        final CallbackContext callbackContext = progressEvent.getCallbackContext();
+        if (callbackContext.isPropagated()) {
+            return progressEvent;
+        }
+
+        callbackContext.setPropagated(true);
+        return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS,
             progressEvent.getResourceModel());
-  }
+    }
 }

--- a/alias/src/main/java/software/amazon/kms/alias/CallbackContext.java
+++ b/alias/src/main/java/software/amazon/kms/alias/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    protected boolean propagated;
 }

--- a/alias/src/main/java/software/amazon/kms/alias/DeleteHandler.java
+++ b/alias/src/main/java/software/amazon/kms/alias/DeleteHandler.java
@@ -25,15 +25,20 @@ public class DeleteHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        return proxy.initiate("kms::delete-alias", proxyClient, model, callbackContext)
-            .translateToServiceRequest(Translator::deleteAliasRequest)
-            .makeServiceCall(aliasHelper::deleteAlias)
-            .done(deleteAliasResponse -> {
-                logger.log(String
-                    .format("%s [%s] has been successfully deleted", ResourceModel.TYPE_NAME,
-                        model.getAliasName()));
+        return ProgressEvent.progress(model, callbackContext)
+            .then(
+                progress -> proxy.initiate("kms::delete-alias", proxyClient, model, callbackContext)
+                    .translateToServiceRequest(Translator::deleteAliasRequest)
+                    .makeServiceCall(aliasHelper::deleteAlias)
+                    .done(deleteAliasResponse -> {
+                        logger.log(String
+                            .format("%s [%s] has been successfully deleted",
+                                ResourceModel.TYPE_NAME,
+                                model.getAliasName()));
 
-                return ProgressEvent.defaultSuccessHandler(model);
-            });
+                        return progress;
+                    }))
+            .then(BaseHandlerStd::propagate)
+            .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 }

--- a/alias/src/main/java/software/amazon/kms/alias/UpdateHandler.java
+++ b/alias/src/main/java/software/amazon/kms/alias/UpdateHandler.java
@@ -30,7 +30,14 @@ public class UpdateHandler extends BaseHandlerStd {
                 progress -> proxy.initiate("kms::update-alias", proxyClient, model, callbackContext)
                     .translateToServiceRequest(Translator::updateAliasRequest)
                     .makeServiceCall(aliasHelper::updateAlias)
-                    .done(createAliasResponse -> progress))
+                    .done(updateAliasResponse -> {
+                        logger.log(String
+                            .format("%s [%s] has been successfully updated",
+                                ResourceModel.TYPE_NAME,
+                                model.getAliasName()));
+
+                        return progress;
+                    }))
             .then(BaseHandlerStd::propagate)
             .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }

--- a/alias/src/main/java/software/amazon/kms/alias/UpdateHandler.java
+++ b/alias/src/main/java/software/amazon/kms/alias/UpdateHandler.java
@@ -25,9 +25,13 @@ public class UpdateHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        return proxy.initiate("kms::update-alias", proxyClient, model, callbackContext)
-            .translateToServiceRequest(Translator::updateAliasRequest)
-            .makeServiceCall(aliasHelper::updateAlias)
-            .done(createAliasResponse -> ProgressEvent.defaultSuccessHandler(model));
+        return ProgressEvent.progress(model, callbackContext)
+            .then(
+                progress -> proxy.initiate("kms::update-alias", proxyClient, model, callbackContext)
+                    .translateToServiceRequest(Translator::updateAliasRequest)
+                    .makeServiceCall(aliasHelper::updateAlias)
+                    .done(createAliasResponse -> progress))
+            .then(BaseHandlerStd::propagate)
+            .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 }

--- a/alias/src/test/java/software/amazon/kms/alias/DeleteHandlerTest.java
+++ b/alias/src/test/java/software/amazon/kms/alias/DeleteHandlerTest.java
@@ -59,9 +59,30 @@ public class DeleteHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_PartiallyPropagate() {
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, new CallbackContext(), proxyKmsClient, logger);
+
+        verify(aliasHelper)
+            .deleteAlias(eq(Translator.deleteAliasRequest(model)), eq(proxyKmsClient));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isNotNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(60);
+        assertThat(response.getCallbackContext().propagated).isEqualTo(true);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        final CallbackContext callbackContext = new CallbackContext();
+        callbackContext.setPropagated(true);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, proxyKmsClient, logger);
 
         verify(aliasHelper)
             .deleteAlias(eq(Translator.deleteAliasRequest(model)), eq(proxyKmsClient));

--- a/alias/src/test/java/software/amazon/kms/alias/UpdateHandlerTest.java
+++ b/alias/src/test/java/software/amazon/kms/alias/UpdateHandlerTest.java
@@ -59,9 +59,30 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_PartiallyPropagate() {
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, new CallbackContext(), proxyKmsClient, logger);
+
+        verify(aliasHelper)
+            .updateAlias(eq(Translator.updateAliasRequest(model)), eq(proxyKmsClient));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isNotNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(60);
+        assertThat(response.getCallbackContext().propagated).isEqualTo(true);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        final CallbackContext callbackContext = new CallbackContext();
+        callbackContext.setPropagated(true);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, proxyKmsClient, logger);
 
         verify(aliasHelper)
             .updateAlias(eq(Translator.updateAliasRequest(model)), eq(proxyKmsClient));

--- a/key/.rpdk-config
+++ b/key/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::KMS::Key",
     "language": "java",
     "runtime": "java8",
@@ -12,5 +13,6 @@
             "key"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.kms.key.HandlerWrapperExecutable"
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*
* Added 60 second eventual consistency propagation delay to Alias creation, deletion, and updates
* Added 60 second propagation delay to Key deletion handler
* Fix code style so that it matches our check style config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
