### PR TITLE
Add Alias Contract Test Inputs & Update Key Contract Test Inputs

### DIFF
--- a/alias/inputs/inputs_1_create.json
+++ b/alias/inputs/inputs_1_create.json
@@ -1,0 +1,4 @@
+{
+  "AliasName": "alias/ContractAlias",
+  "TargetKeyId": "{{ContractTestAliasKey1}}"
+}

--- a/alias/inputs/inputs_1_invalid.json
+++ b/alias/inputs/inputs_1_invalid.json
@@ -1,0 +1,4 @@
+{
+  "AliasName": "alias/ContractAlias",
+  "TargetKeyId": "not_a_key_id"
+}

--- a/alias/inputs/inputs_1_update.json
+++ b/alias/inputs/inputs_1_update.json
@@ -1,0 +1,4 @@
+{
+  "AliasName": "alias/ContractAlias",
+  "TargetKeyId": "{{ContractTestAliasKey2}}"
+}

--- a/alias/src/main/java/software/amazon/kms/alias/DeleteHandler.java
+++ b/alias/src/main/java/software/amazon/kms/alias/DeleteHandler.java
@@ -39,6 +39,6 @@ public class DeleteHandler extends BaseHandlerStd {
                         return progress;
                     }))
             .then(BaseHandlerStd::propagate)
-            .then(progress -> ProgressEvent.defaultSuccessHandler(model));
+            .then(progress -> ProgressEvent.defaultSuccessHandler(null));
     }
 }

--- a/alias/src/test/java/software/amazon/kms/alias/DeleteHandlerTest.java
+++ b/alias/src/test/java/software/amazon/kms/alias/DeleteHandlerTest.java
@@ -91,7 +91,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/key/inputs/inputs_1_create.json
+++ b/key/inputs/inputs_1_create.json
@@ -1,7 +1,5 @@
 {
-  "Description": "[Contract Test] create",
-  "Enabled": true,
-  "EnableKeyRotation": true,
+  "Description": "[Contract Test] Create With Defaults",
   "KeyPolicy": {
     "Version": "2012-10-17",
     "Id": "key-default-1",
@@ -10,13 +8,11 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
-  },
-  "KeyUsage": "ENCRYPT_DECRYPT",
-  "PendingWindowInDays": 7
+  }
 }

--- a/key/inputs/inputs_1_create.json
+++ b/key/inputs/inputs_1_create.json
@@ -8,7 +8,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"

--- a/key/inputs/inputs_1_invalid.json
+++ b/key/inputs/inputs_1_invalid.json
@@ -9,7 +9,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"

--- a/key/inputs/inputs_1_invalid.json
+++ b/key/inputs/inputs_1_invalid.json
@@ -1,8 +1,6 @@
 {
   "KeyId": "123a45b6-7c89-1011-de1f-21314ghi1j51",
-  "Description": "[Contract Test] update",
-  "Enabled": true,
-  "EnableKeyRotation": false,
+  "Description": "[Contract Test] Invalid Update With Defaults",
   "KeyPolicy": {
     "Version": "2012-10-17",
     "Id": "key-default-1",
@@ -11,13 +9,12 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
   },
-  "KeyUsage": "ENCRYPT_DECRYPT_INVALID",
-  "PendingWindowInDays": 7
+  "KeyUsage": "ENCRYPT_DECRYPT_INVALID"
 }

--- a/key/inputs/inputs_1_update.json
+++ b/key/inputs/inputs_1_update.json
@@ -10,7 +10,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"

--- a/key/inputs/inputs_1_update.json
+++ b/key/inputs/inputs_1_update.json
@@ -1,7 +1,7 @@
 {
-  "Description": "[Contract Test] update",
-  "Enabled": true,
-  "EnableKeyRotation": false,
+  "Description": "[Contract Test] Update With Defaults",
+  "Enabled": false,
+  "EnableKeyRotation": true,
   "KeyPolicy": {
     "Version": "2012-10-17",
     "Id": "key-default-1",
@@ -10,13 +10,12 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
   },
-  "KeyUsage": "ENCRYPT_DECRYPT",
   "PendingWindowInDays": 7
 }

--- a/key/inputs/inputs_2_create.json
+++ b/key/inputs/inputs_2_create.json
@@ -1,5 +1,7 @@
 {
-  "Description": "[Contract Test] create asymmetric",
+  "Description": "[Contract Test] Complex Create",
+  "Enabled": false,
+  "EnableKeyRotation": false,
   "KeyPolicy": {
     "Version": "2012-10-17",
     "Id": "key-default-1",
@@ -8,15 +10,15 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
   },
-  "KeySpec": "ECC_NIST_P256",
-  "KeyUsage": "SIGN_VERIFY",
+  "KeySpec": "SYMMETRIC_DEFAULT",
+  "KeyUsage": "ENCRYPT_DECRYPT",
   "PendingWindowInDays": 7,
   "Tags": [
     {

--- a/key/inputs/inputs_2_create.json
+++ b/key/inputs/inputs_2_create.json
@@ -10,7 +10,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"

--- a/key/inputs/inputs_2_invalid.json
+++ b/key/inputs/inputs_2_invalid.json
@@ -1,4 +1,7 @@
 {
+  "KeyId": "123a45b6-7c89-1011-de1f-21314ghi1j51",
+  "Description": "[Contract Test] Complex Invalid Update",
+  "Enabled": true,
   "EnableKeyRotation": true,
   "KeyPolicy": {
     "Version": "2012-10-17",
@@ -8,16 +11,16 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
   },
-  "KeySpec": "ECC_NIST_P256",
-  "KeyUsage": "SIGN_VERIFY",
-  "PendingWindowInDays": 7,
+  "KeySpec": "SYMMETRIC_DEFAULT",
+  "KeyUsage": "ENCRYPT_DECRYPT",
+  "PendingWindowInDays": 1,
   "Tags": [
     {
       "Key": "Key",

--- a/key/inputs/inputs_2_invalid.json
+++ b/key/inputs/inputs_2_invalid.json
@@ -11,7 +11,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"

--- a/key/inputs/inputs_2_update.json
+++ b/key/inputs/inputs_2_update.json
@@ -1,5 +1,7 @@
 {
-  "Enabled": false,
+  "Description": "[Contract Test] Complex Update",
+  "Enabled": true,
+  "EnableKeyRotation": false,
   "KeyPolicy": {
     "Version": "2012-10-17",
     "Id": "key-default-1",
@@ -8,16 +10,16 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${userAccount}:root"
+          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"
       }
     ]
   },
-  "KeySpec": "ECC_NIST_P256",
-  "KeyUsage": "SIGN_VERIFY",
-  "PendingWindowInDays": 7,
+  "KeySpec": "SYMMETRIC_DEFAULT",
+  "KeyUsage": "ENCRYPT_DECRYPT",
+  "PendingWindowInDays": 8,
   "Tags": [
     {
       "Key": "Key",

--- a/key/inputs/inputs_2_update.json
+++ b/key/inputs/inputs_2_update.json
@@ -10,7 +10,7 @@
         "Sid": "Enable IAM User Permissions",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{{AWSAccountId}}:root"
+          "AWS": "arn:{{AWSPartition}}:iam::{{AWSAccountId}}:root"
         },
         "Action": "kms:*",
         "Resource": "*"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

* Add contract tests for alias resource
* Fix bug in alias resource that was causing the contract tests to fail
* Update the key contract tests so that they pull their account Id from CFN
* Update the key contract tests so that they use a KeySpec that is available in all regions (So the contract tests don't fail when run against regions like cn-north-1 and cn-northwest-1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
