### PR TITLE
Explicitly set taggable & replace null error messages

### DIFF
--- a/alias/aws-kms-alias.json
+++ b/alias/aws-kms-alias.json
@@ -28,6 +28,7 @@
   "primaryIdentifier": [
     "/properties/AliasName"
   ],
+  "taggable": false,
   "handlers": {
     "create": {
       "permissions": [

--- a/common/src/test/java/software/amazon/kms/common/AbstractKmsApiHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/AbstractKmsApiHelperTest.java
@@ -1,6 +1,8 @@
 package software.amazon.kms.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.fail;
 import static software.amazon.kms.common.KeyApiHelper.ACCESS_DENIED_ERROR_CODE;
 import static software.amazon.kms.common.KeyApiHelper.THROTTLING_ERROR_CODE;
 import static software.amazon.kms.common.KeyApiHelper.VALIDATION_ERROR_CODE;
@@ -139,5 +141,20 @@ public class AbstractKmsApiHelperTest {
 
         assertThatExceptionOfType(CfnGeneralServiceException.class)
             .isThrownBy(() -> mockKmsApiHelper.testExceptionWrapping(generalKmsException));
+    }
+
+    @Test
+    public void testAddMessageIfNull() {
+        final MalformedPolicyDocumentException malformedPolicyDocumentException = MalformedPolicyDocumentException.builder()
+                .message("null (Service: Kms, Status Code: 400, Request ID: null, Extended Request ID: null)")
+                .build();
+
+        try {
+            mockKmsApiHelper.testExceptionWrapping(malformedPolicyDocumentException);
+            fail("Expected CfnInvalidRequestException");
+        } catch (final CfnInvalidRequestException e) {
+            assertThat(e.getMessage()).isEqualTo("MockOperation failed due to MalformedPolicyDocumentException " +
+                    "(Service: Kms, Status Code: 400, Request ID: null, Extended Request ID: null)");
+        }
     }
 }

--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -114,6 +114,7 @@
   "writeOnlyProperties": [
     "/properties/PendingWindowInDays"
   ],
+  "taggable": true,
   "handlers": {
     "create": {
       "permissions": [

--- a/replicakey/aws-kms-replicakey.json
+++ b/replicakey/aws-kms-replicakey.json
@@ -91,6 +91,7 @@
   "writeOnlyProperties": [
     "/properties/PendingWindowInDays"
   ],
+  "taggable": true,
   "handlers": {
     "create": {
       "permissions": [


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

* Explicitly set taggable in resource definitions
* Replace 'null' error messages with a message containing the operation and the exception type. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
