### PR TITLE
Update Soft Fail Logic when customer attempts to modify tags

### DIFF
--- a/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
+++ b/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
@@ -200,6 +200,7 @@ public class UpdateHandlerTest {
                 eq(callbackContext)))
             .thenThrow(CfnAccessDeniedException.class);
 
+
         // Set up our request
         final ResourceHandlerRequest<ResourceModel> request =
             ResourceHandlerRequest.<ResourceModel>builder()
@@ -235,6 +236,8 @@ public class UpdateHandlerTest {
         verify(eventualConsistencyHandlerHelper).waitForChangesToPropagate(eq(inProgressEvent));
 
         // We shouldn't call anything else
+
+
         verifyZeroInteractions(keyApiHelper);
         verifyNoMoreInteractions(keyHandlerHelper);
         verifyNoMoreInteractions(eventualConsistencyHandlerHelper);


### PR DESCRIPTION
*Description of changes:*
Update Soft Fail Logic when customer attempts to modify tags. Handler returns a failure if keys are updated by a customer who does not have the permissions to update tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
