### PR TITLE
Softfail

### DIFF
--- a/common/src/test/java/software/amazon/kms/common/TestConstants.java
+++ b/common/src/test/java/software/amazon/kms/common/TestConstants.java
@@ -32,6 +32,9 @@ public class TestConstants {
     public static final Map<String, String> TAGS = new ImmutableMap.Builder<String, String>()
         .put("Key1", "Value1")
         .build();
+    public static final Map<String, String> PREVIOUS_TAGS = new ImmutableMap.Builder<String, String>()
+            .put("Key2", "Value2")
+            .build();
     public static final Set<Tag> SDK_TAGS = new ImmutableSet.Builder<Tag>()
         .add(Tag.builder().tagKey("Key1").tagValue("Value1").build())
         .build();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Remove tagging update soft fail logic when a customer attempts to modify tags
so that customers know that they are missing tagging permissions, and that their tagging update failed

We currently ignore all access denied errors during tagging updates. This means that when a customer is missing tagging permissions, and they update their resource tags in their CFN template, the operation will appear to succeed, when it really failed due to an access denied exception. Soft failing is required so that we do not break customers that created their resources prior to the tagging feature being added to the Key resource. Instead of always soft failing, we should selectively soft fail, only when the customer has not requested any updates to their tags. We should be able to do this by comparing the current resource model with the previous resource model that is provided in our Key handler’s context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
