### PR TITLE
Soft fail logic on tags update to reflect stack drifts

### DIFF
--- a/common/src/test/java/software/amazon/kms/common/TestConstants.java
+++ b/common/src/test/java/software/amazon/kms/common/TestConstants.java
@@ -32,6 +32,9 @@ public class TestConstants {
     public static final Map<String, String> TAGS = new ImmutableMap.Builder<String, String>()
         .put("Key1", "Value1")
         .build();
+    public static final Map<String, String> PREVIOUS_TAGS = new ImmutableMap.Builder<String, String>()
+            .put("Key2", "Value2")
+            .build();
     public static final Set<Tag> SDK_TAGS = new ImmutableSet.Builder<Tag>()
         .add(Tag.builder().tagKey("Key1").tagValue("Value1").build())
         .build();

--- a/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
+++ b/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
@@ -1,7 +1,9 @@
 package software.amazon.kms.key;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -132,6 +134,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(KEY_MODEL_PREVIOUS)
                 .desiredResourceState(KEY_MODEL)
                 .desiredResourceTags(TestConstants.TAGS)
+                .previousResourceTags(TestConstants.PREVIOUS_TAGS)
                 .build();
 
         // Execute the update handler and make sure it returns the expected results
@@ -167,7 +170,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void handleRequest_SoftFailAccessDenied() {
+    public void handleRequest_TagUpdateAccessDenied() {
         // Mock out delegation to our helpers and make them return an IN_PROGRESS event
         final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
             ProgressEvent.progress(KEY_MODEL, callbackContext);
@@ -191,10 +194,7 @@ public class UpdateHandlerTest {
             .updateKeyPolicy(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS), eq(KEY_MODEL),
                 eq(callbackContext)))
             .thenReturn(inProgressEvent);
-        when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
-            .thenReturn(inProgressEvent);
-
-        // Throw a CfnAccessDeniedException from updateKeyTags so we can test that it is soft failed
+        // Throw CfnAccessDeniedException to mock no kms:TagResource permission
         when(keyHandlerHelper
             .updateKeyTags(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(TestConstants.TAGS),
                 eq(callbackContext)))
@@ -206,9 +206,83 @@ public class UpdateHandlerTest {
                 .previousResourceState(KEY_MODEL_PREVIOUS)
                 .desiredResourceState(KEY_MODEL)
                 .desiredResourceTags(TestConstants.TAGS)
+                .previousResourceTags(TestConstants.PREVIOUS_TAGS)
                 .build();
 
-        // Execute the update handler, our soft failing should ignore the CfnAccessDeniedException
+        assertThatExceptionOfType(CfnAccessDeniedException.class).isThrownBy(() ->
+                handler.handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER));
+
+        // Make sure we called our helpers with the correct parameters and the propagation fails at updateKeyTags
+        verify(keyHandlerHelper)
+            .describeKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(callbackContext),
+                eq(false));
+        verify(keyHandlerHelper)
+            .enableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext), eq(true));
+        verify(keyHandlerHelper)
+            .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext));
+        verify(keyHandlerHelper)
+            .updateKeyDescription(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext));
+        verify(keyHandlerHelper)
+            .updateKeyPolicy(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS), eq(KEY_MODEL),
+                eq(callbackContext));
+        verify(keyHandlerHelper)
+            .updateKeyTags(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(TestConstants.TAGS),
+                eq(callbackContext));
+        verify(eventualConsistencyHandlerHelper, times(0)).waitForChangesToPropagate(eq(inProgressEvent));
+
+        // We shouldn't call anything else
+        verifyZeroInteractions(keyApiHelper);
+        verifyNoMoreInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+
+
+    @Test
+    public void handleRequest_SoftFailSucess() {
+        // Mock out delegation to our helpers and make them return an IN_PROGRESS event
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+            ProgressEvent.progress(KEY_MODEL, callbackContext);
+        when(keyHandlerHelper
+            .describeKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(callbackContext),
+                eq(false)))
+            .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+            .enableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext), eq(true)))
+            .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+            .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext)))
+            .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+            .updateKeyDescription(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS),
+                eq(KEY_MODEL), eq(callbackContext)))
+            .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+            .updateKeyPolicy(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_PREVIOUS), eq(KEY_MODEL),
+                eq(callbackContext)))
+            .thenReturn(inProgressEvent);
+        // Throw CfnAccessDeniedException to mock no kms:TagResource permission
+        when(keyHandlerHelper
+            .updateKeyTags(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(TestConstants.TAGS),
+                eq(callbackContext)))
+            .thenThrow(CfnAccessDeniedException.class);
+         when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
+             .thenReturn(inProgressEvent);
+
+        // Set up our request
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(KEY_MODEL_PREVIOUS)
+                .desiredResourceState(KEY_MODEL)
+                .desiredResourceTags(TestConstants.TAGS)
+                .previousResourceTags(TestConstants.TAGS)
+                .build();
+
+        // Execute the update handler and make sure it returns the expected results
         assertThat(handler
             .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER))
             .isEqualTo(ProgressEvent.defaultSuccessHandler(KEY_MODEL_REDACTED));


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
Remove tagging update soft fail logic when a customer attempts to modify tags
so that customers know that they are missing tagging permissions, and that their tagging update failed

We currently ignore all access denied errors during tagging updates. This means that when a customer is missing tagging permissions, and they update their resource tags in their CFN template, the operation will appear to succeed, when it really failed due to an access denied exception. Soft failing is required so that we do not break customers that created their resources prior to the tagging feature being added to the Key resource. Instead of always soft failing, we should selectively soft fail, only when the customer has not requested any updates to their tags. We should be able to do this by comparing the current resource model with the previous resource model that is provided in our Key handler’s context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.