### PR TITLE
Check if alias already exists prior to calling CreateAlias

### DIFF
--- a/alias/src/main/java/software/amazon/kms/alias/CallbackContext.java
+++ b/alias/src/main/java/software/amazon/kms/alias/CallbackContext.java
@@ -6,6 +6,12 @@ import software.amazon.kms.common.EventualConsistencyCallbackContext;
  * The only context needed for the Alias handlers is the common eventual consistency context.
  * This class is still required since the CFN java plugin expects it to be here, with this name.
  */
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.NoArgsConstructor
+@lombok.AllArgsConstructor
 public class CallbackContext extends EventualConsistencyCallbackContext {
-
+    private boolean isPreCreateCheckDone;
 }

--- a/alias/src/main/java/software/amazon/kms/alias/CreateHandler.java
+++ b/alias/src/main/java/software/amazon/kms/alias/CreateHandler.java
@@ -1,6 +1,12 @@
 package software.amazon.kms.alias;
 
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.CreateAliasResponse;
+import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
+import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
+import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -30,11 +36,45 @@ public class CreateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
 
         return ProgressEvent.progress(model, callbackContext)
+            .then(progress -> {
+                if (progress.getCallbackContext().isPreCreateCheckDone()) {
+                    return progress;
+                } else {
+                    return proxy.initiate("kms::describe-key", proxyClient, model, progress.getCallbackContext())
+                            .translateToServiceRequest(resourceModel ->
+                                    DescribeKeyRequest.builder().keyId(resourceModel.getAliasName()).build())
+                            .makeServiceCall((describeKeyRequest, client) -> {
+                                boolean aliasExists;
+                                try {
+                                    aliasApiHelper.describeKey(describeKeyRequest, client);
+                                    aliasExists = true;
+                                } catch (final CfnNotFoundException e) {
+                                    aliasExists = false;
+                                } catch (final CfnAccessDeniedException e) {
+                                    aliasExists = true;
+                                }
+
+                                if (aliasExists) {
+                                    throw new CfnAlreadyExistsException("AWS::KMS::Alias", model.getAliasName());
+                                } else {
+                                    progress.getCallbackContext().setPreCreateCheckDone(true);
+                                    return DescribeKeyResponse.builder().build();
+                                }
+                            }).progress(1);
+                }
+            })
             .then(
-                progress -> proxy.initiate("kms::create-alias", proxyClient, model, callbackContext)
+                progress -> proxy.initiate("kms::create-alias", proxyClient, model, progress.getCallbackContext())
                     .translateToServiceRequest(Translator::createAliasRequest)
-                    .makeServiceCall(aliasApiHelper::createAlias)
-                    .done(createAliasResponse -> {
+                    .makeServiceCall((createAliasRequest, client) -> {
+                        try {
+                            return aliasApiHelper.createAlias(createAliasRequest, client);
+                        } catch (final CfnAlreadyExistsException e) {
+                            // We already confirmed the alias did not exist on initial run of handler. If it exists
+                            // now, then this must be a retry of CreateAlias.
+                            return CreateAliasResponse.builder().build();
+                        }
+                    }).done(createAliasResponse -> {
                         logger.log(String
                             .format("%s [%s] has been successfully created",
                                 ResourceModel.TYPE_NAME,

--- a/common/src/main/java/software/amazon/kms/common/AbstractKmsApiHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/AbstractKmsApiHelper.java
@@ -4,8 +4,11 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Strings;
 
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.AlreadyExistsException;
 import software.amazon.awssdk.services.kms.model.DependencyTimeoutException;
+import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
+import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
 import software.amazon.awssdk.services.kms.model.DisabledException;
 import software.amazon.awssdk.services.kms.model.InvalidAliasNameException;
 import software.amazon.awssdk.services.kms.model.InvalidArnException;
@@ -28,6 +31,7 @@ import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorExceptio
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.exceptions.CfnUnauthorizedTaggingOperationException;
+import software.amazon.cloudformation.proxy.ProxyClient;
 
 /**
  * Abstract Helper class for calling KMS APIs. The primary function of this class
@@ -43,6 +47,14 @@ public class AbstractKmsApiHelper {
     public static final String KMS_UNTAG_RESOURCE_PERMISSION = "kms:UntagResource";
     public static final String KMS_LIST_RESOURCE_TAGS_PERMISSION = "kms:ListResourceTags";
 
+    private static final String DESCRIBE_KEY = "DescribeKey";
+
+    public DescribeKeyResponse describeKey(final DescribeKeyRequest describeKeyRequest,
+            final ProxyClient<KmsClient> proxyClient) {
+        return wrapKmsExceptions(DESCRIBE_KEY,
+                () -> proxyClient.injectCredentialsAndInvokeV2(describeKeyRequest,
+                        proxyClient.client()::describeKey));
+    }
 
     protected <T> T wrapKmsExceptions(final String operation, final Supplier<T> serviceCall) {
         try {

--- a/common/src/main/java/software/amazon/kms/common/KeyApiHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/KeyApiHelper.java
@@ -45,7 +45,6 @@ public class KeyApiHelper extends AbstractKmsApiHelper {
 
     private static final String CREATE_KEY = "CreateKey";
     private static final String REPLICATE_KEY = "ReplicateKey";
-    private static final String DESCRIBE_KEY = "DescribeKey";
     private static final String DISABLE_KEY = "DisableKey";
     private static final String ENABLE_KEY = "EnableKey";
     private static final String DISABLE_KEY_ROTATION = "DisableKeyRotation";
@@ -72,13 +71,6 @@ public class KeyApiHelper extends AbstractKmsApiHelper {
         return wrapKmsExceptions(REPLICATE_KEY,
             () -> proxyClient.injectCredentialsAndInvokeV2(replicateKeyRequest,
                 proxyClient.client()::replicateKey));
-    }
-
-    public DescribeKeyResponse describeKey(final DescribeKeyRequest describeKeyRequest,
-                                           final ProxyClient<KmsClient> proxyClient) {
-        return wrapKmsExceptions(DESCRIBE_KEY,
-            () -> proxyClient.injectCredentialsAndInvokeV2(describeKeyRequest,
-                proxyClient.client()::describeKey));
     }
 
     public DisableKeyResponse disableKey(final DisableKeyRequest disableKeyRequest,

--- a/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
@@ -89,18 +89,6 @@ public class KeyApiHelperTest {
     }
 
     @Test
-    public void testDescribeKey() {
-        final DescribeKeyRequest describeKeyRequest = DescribeKeyRequest.builder().build();
-        final DescribeKeyResponse describeKeyResponse = DescribeKeyResponse.builder().build();
-
-        doReturn(describeKeyResponse).when(proxy)
-            .injectCredentialsAndInvokeV2(same(describeKeyRequest), any());
-
-        assertThat(keyApiHelper.describeKey(describeKeyRequest, proxyKmsClient))
-            .isEqualTo(describeKeyResponse);
-    }
-
-    @Test
     public void testDisableKey() {
         final DisableKeyRequest disableKeyRequest = DisableKeyRequest.builder().build();
         final DisableKeyResponse disableKeyResponse = DisableKeyResponse.builder().build();


### PR DESCRIPTION
*Issue #, if available:* Internal

### Description of changes

Alias CreateHandler is currently non-idempotent. If a transient error causes the CreateHandler to be retried after it already called CreateAlias, then all retries will fail will AlreadyExists errors.

This change follows CFN's recommendation fix for the non-idempotent behavior when an API doesn't support ClientToken parameters for idempotency. The strategy is to do a DescribeKey request on the alias prior to creation to verify whether it is pre-existing or not. If the alias exists, fail with AlreadyExists. If the alias does not exist, then mark in callback context that the pre-create check was done, and proceed to call CreateAlias (and retry any AlreadyExists errors from the API).

This change requires no new KMS permissions to call DescribeKey. This is because AccessDenied and a successful DescribeKey response are both indicators of an alias's existence within the same account of a caller.

### Testing

Verified expected behavior by creating stacks with new/re-used aliases using a role with/without DescribeKey permissions.

```
cfn submit --set-default --no-role -v
```



---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
