### PR TITLE
KMS::Key Performance changes in Create & Delete Handler

### DIFF
--- a/common/src/main/java/software/amazon/kms/common/CreatableKeyHandlerHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/CreatableKeyHandlerHelper.java
@@ -47,12 +47,7 @@ public class CreatableKeyHandlerHelper<M, C extends KeyCallbackContext, T extend
                 // since updating writable metadata at this point would only
                 // overwrite the properties supplied in the CFN template.
                 keyTranslator.setReadOnlyKeyMetadata(model, createKeyResponse.keyMetadata());
-
-                // Wait for key state to propagate to other hosts
-                return ProgressEvent
-                    .defaultInProgressHandler(callbackContext,
-                        EventualConsistencyHandlerHelper.EVENTUAL_CONSISTENCY_DELAY_SECONDS,
-                        model);
+                return ProgressEvent.progress(model, callbackContext);
             });
     }
 }

--- a/common/src/main/java/software/amazon/kms/common/EventualConsistencyCallbackContext.java
+++ b/common/src/main/java/software/amazon/kms/common/EventualConsistencyCallbackContext.java
@@ -13,4 +13,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.AllArgsConstructor
 public class EventualConsistencyCallbackContext extends StdCallbackContext {
     protected boolean propagationComplete;
+    protected boolean updateRequest = true;
 }

--- a/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
@@ -6,7 +6,7 @@ public class EventualConsistencyHandlerHelper <M, C extends EventualConsistencyC
     // It may take up to 60 seconds for changes to propagate throughout the region for update
     // operation due to cache TTl set to 60 sec.
     public static final int EVENTUAL_CONSISTENCY_DELAY_SECONDS = 60;
-    //Eventual consistency delay for create & delete operation to 15 secs
+    // Eventual consistency delay for create & delete operation to 15 secs
     public static final int CREATE_DELETE_EVENTUAL_CONSISTENCY_DELAY_SECONDS = 15;
 
     /**

--- a/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
@@ -22,9 +22,8 @@ public class EventualConsistencyHandlerHelper <M, C extends EventualConsistencyC
         callbackContext.setPropagationComplete(true);
         int delaySeconds = callbackContext.isUpdateRequest() ? EVENTUAL_CONSISTENCY_DELAY_SECONDS :
                 CREATE_DELETE_EVENTUAL_CONSISTENCY_DELAY_SECONDS;
-        return ProgressEvent.defaultInProgressHandler(callbackContext,
-                delaySeconds,
-            progressEvent.getResourceModel());
+        return ProgressEvent.defaultInProgressHandler(callbackContext, delaySeconds,
+                progressEvent.getResourceModel());
     }
 
     /**

--- a/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/EventualConsistencyHandlerHelper.java
@@ -3,8 +3,11 @@ package software.amazon.kms.common;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 
 public class EventualConsistencyHandlerHelper <M, C extends EventualConsistencyCallbackContext> {
-    // It may take up to 60 seconds for changes to propagate throughout the region
+    // It may take up to 60 seconds for changes to propagate throughout the region for update
+    // operation due to cache TTl set to 60 sec.
     public static final int EVENTUAL_CONSISTENCY_DELAY_SECONDS = 60;
+    //Eventual consistency delay for create & delete operation to 15 secs
+    public static final int CREATE_DELETE_EVENTUAL_CONSISTENCY_DELAY_SECONDS = 15;
 
     /**
      * Perform the final propagation delay to make sure the latest
@@ -17,8 +20,19 @@ public class EventualConsistencyHandlerHelper <M, C extends EventualConsistencyC
         }
 
         callbackContext.setPropagationComplete(true);
+        int delaySeconds = callbackContext.isUpdateRequest() ? EVENTUAL_CONSISTENCY_DELAY_SECONDS :
+                CREATE_DELETE_EVENTUAL_CONSISTENCY_DELAY_SECONDS;
         return ProgressEvent.defaultInProgressHandler(callbackContext,
-            EVENTUAL_CONSISTENCY_DELAY_SECONDS,
+                delaySeconds,
             progressEvent.getResourceModel());
+    }
+
+    /**
+     * Method for setting the request type, based on it the eventual consistency delay is determined.
+     */
+    public ProgressEvent<M, C> setRequestType(final ProgressEvent<M, C> progressEvent, boolean isUpdateRequest) {
+        progressEvent.getCallbackContext().setUpdateRequest(isUpdateRequest);
+        return progressEvent;
+
     }
 }

--- a/common/src/main/java/software/amazon/kms/common/KeyHandlerHelper.java
+++ b/common/src/main/java/software/amazon/kms/common/KeyHandlerHelper.java
@@ -233,9 +233,9 @@ public class KeyHandlerHelper<M, C extends KeyCallbackContext, T extends KeyTran
             return proxy.initiate("kms::disable-key", proxyClient, model, callbackContext)
                 .translateToServiceRequest(keyTranslator::disableKeyRequest)
                     .backoffDelay(stabilizeDelay)
-                    .makeServiceCall((disableKeyRequest, proxyClient1) -> {
+                    .makeServiceCall((disableKeyRequest, disableKeyProxyClient) -> {
                         try {
-                            return keyApiHelper.disableKey((DisableKeyRequest) disableKeyRequest, proxyClient1);
+                            return keyApiHelper.disableKey((DisableKeyRequest) disableKeyRequest, disableKeyProxyClient);
                         } catch (Exception e) {
                             if (e instanceof CfnNotFoundException) {
                                 throw NotFoundException.builder()

--- a/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
@@ -80,8 +80,7 @@ public class CreatableKeyHandlerHelperTest {
 
         assertThat(keyHandlerHelper
             .createKey(proxy, proxyKmsClient, MOCK_MODEL, keyCallbackContext, TestConstants.TAGS))
-            .isEqualTo(ProgressEvent.defaultInProgressHandler(keyCallbackContext,
-                0, MOCK_MODEL));
+            .isEqualTo(ProgressEvent.progress(MOCK_MODEL, keyCallbackContext));
 
         verify(keyTranslator).setReadOnlyKeyMetadata(eq(MOCK_MODEL), eq(KEY_METADATA));
     }

--- a/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
@@ -81,7 +81,7 @@ public class CreatableKeyHandlerHelperTest {
         assertThat(keyHandlerHelper
             .createKey(proxy, proxyKmsClient, MOCK_MODEL, keyCallbackContext, TestConstants.TAGS))
             .isEqualTo(ProgressEvent.defaultInProgressHandler(keyCallbackContext,
-                EventualConsistencyHandlerHelper.EVENTUAL_CONSISTENCY_DELAY_SECONDS, MOCK_MODEL));
+                0, MOCK_MODEL));
 
         verify(keyTranslator).setReadOnlyKeyMetadata(eq(MOCK_MODEL), eq(KEY_METADATA));
     }

--- a/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/CreatableKeyHandlerHelperTest.java
@@ -80,7 +80,7 @@ public class CreatableKeyHandlerHelperTest {
 
         assertThat(keyHandlerHelper
             .createKey(proxy, proxyKmsClient, MOCK_MODEL, keyCallbackContext, TestConstants.TAGS))
-            .isEqualTo(ProgressEvent.progress(MOCK_MODEL, keyCallbackContext));
+                .isEqualTo(ProgressEvent.progress(MOCK_MODEL, keyCallbackContext));
 
         verify(keyTranslator).setReadOnlyKeyMetadata(eq(MOCK_MODEL), eq(KEY_METADATA));
     }

--- a/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
@@ -120,9 +120,9 @@ public class KeyApiHelperTest {
         final DisableKeyRequest disableKeyRequest = DisableKeyRequest.builder().build();
         doThrow(NotFoundException.class).when(proxy)
                 .injectCredentialsAndInvokeV2(same(disableKeyRequest), any());
-        try{
+        try {
             keyApiHelper.disableKey(disableKeyRequest, proxyKmsClient);
-        }catch(Exception e){
+        } catch (Exception e) {
             assertThat(e instanceof CfnNotFoundException);
         }
     }
@@ -173,9 +173,9 @@ public class KeyApiHelperTest {
                 EnableKeyRotationRequest.builder().build();
         doThrow(NotFoundException.class).when(proxy)
                 .injectCredentialsAndInvokeV2(same(enableKeyRotationRequest), any());
-        try{
+        try {
             keyApiHelper.enableKeyRotation(enableKeyRotationRequest, proxyKmsClient);
-        }catch(Exception e){
+        } catch (Exception e) {
             assertThat(e instanceof CfnNotFoundException);
         }
     }

--- a/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyApiHelperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.services.kms.model.ListKeysRequest;
 import software.amazon.awssdk.services.kms.model.ListKeysResponse;
 import software.amazon.awssdk.services.kms.model.ListResourceTagsRequest;
 import software.amazon.awssdk.services.kms.model.ListResourceTagsResponse;
+import software.amazon.awssdk.services.kms.model.NotFoundException;
 import software.amazon.awssdk.services.kms.model.PutKeyPolicyRequest;
 import software.amazon.awssdk.services.kms.model.PutKeyPolicyResponse;
 import software.amazon.awssdk.services.kms.model.ReplicateKeyRequest;
@@ -44,6 +46,7 @@ import software.amazon.awssdk.services.kms.model.UntagResourceRequest;
 import software.amazon.awssdk.services.kms.model.UntagResourceResponse;
 import software.amazon.awssdk.services.kms.model.UpdateKeyDescriptionRequest;
 import software.amazon.awssdk.services.kms.model.UpdateKeyDescriptionResponse;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
@@ -113,6 +116,18 @@ public class KeyApiHelperTest {
     }
 
     @Test
+    public void testDisableKeyFailed() {
+        final DisableKeyRequest disableKeyRequest = DisableKeyRequest.builder().build();
+        doThrow(NotFoundException.class).when(proxy)
+                .injectCredentialsAndInvokeV2(same(disableKeyRequest), any());
+        try{
+            keyApiHelper.disableKey(disableKeyRequest, proxyKmsClient);
+        }catch(Exception e){
+            assertThat(e instanceof CfnNotFoundException);
+        }
+    }
+
+    @Test
     public void testEnableKey() {
         final EnableKeyRequest enableKeyRequest = EnableKeyRequest.builder().build();
         final EnableKeyResponse enableKeyResponse = EnableKeyResponse.builder().build();
@@ -150,6 +165,19 @@ public class KeyApiHelperTest {
 
         assertThat(keyApiHelper.enableKeyRotation(enableKeyRotationRequest, proxyKmsClient))
             .isEqualTo(enableKeyRotationResponse);
+    }
+
+    @Test
+    public void testEnableKeyRotationFailed() {
+        final EnableKeyRotationRequest enableKeyRotationRequest =
+                EnableKeyRotationRequest.builder().build();
+        doThrow(NotFoundException.class).when(proxy)
+                .injectCredentialsAndInvokeV2(same(enableKeyRotationRequest), any());
+        try{
+            keyApiHelper.enableKeyRotation(enableKeyRotationRequest, proxyKmsClient);
+        }catch(Exception e){
+            assertThat(e instanceof CfnNotFoundException);
+        }
     }
 
     @Test

--- a/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
@@ -345,7 +345,7 @@ public class KeyHandlerHelperTest {
         when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
 
         assertThat(keyHandlerHelper.disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
-                        keyCallbackContext))
+                keyCallbackContext))
                 .isEqualTo(ProgressEvent.failed(MOCK_MODEL, keyCallbackContext,
                         HandlerErrorCode.NotStabilized, NOT_STABILIZED_ERROR_MESSAGE));
 
@@ -364,11 +364,10 @@ public class KeyHandlerHelperTest {
 
         try {
             keyHandlerHelper.disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
-                            keyCallbackContext);
+                    keyCallbackContext);
         } catch (Exception e) {
             assertThat(e).isInstanceOf(CfnInvalidRequestException.class);
         }
-
 
         verify(keyApiHelper, atLeast(1)).disableKey(any(DisableKeyRequest.class)
                 , eq(proxyKmsClient));

--- a/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 import com.google.common.collect.ImmutableMap;
@@ -315,7 +318,7 @@ public class KeyHandlerHelperTest {
     public void testDisableKeyRetry() {
         keyHandlerHelper =
                 new KeyHandlerHelper<>(TestConstants.MOCK_TYPE_NAME, keyApiHelper,
-                        eventualConsistencyHandlerHelper, keyTranslator,null);
+                        eventualConsistencyHandlerHelper, keyTranslator, null);
         when(keyApiHelper.disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient))).thenThrow(CfnNotFoundException.class).thenReturn(DisableKeyResponse.builder().build());
         when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
 
@@ -324,23 +327,23 @@ public class KeyHandlerHelperTest {
                         keyCallbackContext))
                 .isEqualTo(ProgressEvent.progress(MOCK_MODEL, keyCallbackContext));
 
-        verify(keyApiHelper,times(2)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
+        verify(keyApiHelper, times(2)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
     }
 
     @Test
     public void testDisableKeyRetryFailed() {
         keyHandlerHelper =
                 new KeyHandlerHelper<>(TestConstants.MOCK_TYPE_NAME, keyApiHelper,
-                        eventualConsistencyHandlerHelper, keyTranslator,BACKOFF_STRATEGY);
+                        eventualConsistencyHandlerHelper, keyTranslator, BACKOFF_STRATEGY);
         when(keyApiHelper.disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient))).thenThrow(CfnNotFoundException.class);
         when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
 
         assertThat(keyHandlerHelper
                 .disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
                         keyCallbackContext))
-                .isEqualTo(ProgressEvent.failed(MOCK_MODEL, keyCallbackContext,HandlerErrorCode.NotStabilized,"Exceeded attempts to wait"));
+                .isEqualTo(ProgressEvent.failed(MOCK_MODEL, keyCallbackContext, HandlerErrorCode.NotStabilized, "Exceeded attempts to wait"));
 
-        verify(keyApiHelper,atLeast(1)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
+        verify(keyApiHelper, atLeast(1)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
     }
 
     @Test

--- a/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyHandlerHelperTest.java
@@ -4,9 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
 
 
 import com.google.common.collect.ImmutableMap;
@@ -27,6 +26,7 @@ import software.amazon.awssdk.services.kms.model.KeySpec;
 import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
 import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
 import software.amazon.awssdk.services.kms.model.DisableKeyRequest;
+import software.amazon.awssdk.services.kms.model.DisableKeyResponse;
 import software.amazon.awssdk.services.kms.model.EnableKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetKeyPolicyRequest;
 import software.amazon.awssdk.services.kms.model.GetKeyPolicyResponse;
@@ -50,10 +50,13 @@ import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Delay;
+import software.amazon.cloudformation.proxy.delay.CappedExponential;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+
 
 @ExtendWith(MockitoExtension.class)
 public class KeyHandlerHelperTest {
@@ -97,6 +100,14 @@ public class KeyHandlerHelperTest {
     private KeyHandlerHelper<Object, KeyCallbackContext, KeyTranslator<Object>> keyHandlerHelper;
     private ProxyClient<KmsClient> proxyKmsClient;
     private KeyCallbackContext keyCallbackContext;
+
+    Delay BACKOFF_STRATEGY =
+            CappedExponential.of()
+                    .minDelay(Duration.ofSeconds(1))
+                    .maxDelay(Duration.ofSeconds(2))
+                    .powerBy(1.3)
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
 
     @BeforeEach
     public void setup() {
@@ -301,6 +312,57 @@ public class KeyHandlerHelperTest {
     }
 
     @Test
+    public void testDisableKeyRetry() {
+        keyHandlerHelper =
+                new KeyHandlerHelper<>(TestConstants.MOCK_TYPE_NAME, keyApiHelper,
+                        eventualConsistencyHandlerHelper, keyTranslator,null);
+        when(keyApiHelper.disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient))).thenThrow(CfnNotFoundException.class).thenReturn(DisableKeyResponse.builder().build());
+        when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
+
+        assertThat(keyHandlerHelper
+                .disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
+                        keyCallbackContext))
+                .isEqualTo(ProgressEvent.progress(MOCK_MODEL, keyCallbackContext));
+
+        verify(keyApiHelper,times(2)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
+    }
+
+    @Test
+    public void testDisableKeyRetryFailed() {
+        keyHandlerHelper =
+                new KeyHandlerHelper<>(TestConstants.MOCK_TYPE_NAME, keyApiHelper,
+                        eventualConsistencyHandlerHelper, keyTranslator,BACKOFF_STRATEGY);
+        when(keyApiHelper.disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient))).thenThrow(CfnNotFoundException.class);
+        when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
+
+        assertThat(keyHandlerHelper
+                .disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
+                        keyCallbackContext))
+                .isEqualTo(ProgressEvent.failed(MOCK_MODEL, keyCallbackContext,HandlerErrorCode.NotStabilized,"Exceeded attempts to wait"));
+
+        verify(keyApiHelper,atLeast(1)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
+    }
+
+    @Test
+    public void testDisableKeyFailed() {
+        keyHandlerHelper =
+                new KeyHandlerHelper<>(TestConstants.MOCK_TYPE_NAME, keyApiHelper,
+                        eventualConsistencyHandlerHelper, keyTranslator,BACKOFF_STRATEGY);
+        when(keyApiHelper.disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient))).thenThrow(new CfnInvalidRequestException("AWS::KMS::Key"));
+        when(keyTranslator.getKeyEnabled(eq(MOCK_MODEL))).thenReturn(false);
+
+        try{keyHandlerHelper
+                .disableKeyIfNecessary(proxy, proxyKmsClient, null, MOCK_MODEL,
+                        keyCallbackContext);}
+        catch(Exception e){
+            assertThat(e).isInstanceOf(CfnInvalidRequestException.class);
+        }
+
+
+        verify(keyApiHelper,atLeast(1)).disableKey(any(DisableKeyRequest.class), eq(proxyKmsClient));
+    }
+
+    @Test
     public void testRetrieveResourceTags() {
         final ListResourceTagsResponse listResourceTagsResponse = ListResourceTagsResponse.builder()
             .tags(TestConstants.SDK_TAGS)
@@ -409,6 +471,8 @@ public class KeyHandlerHelperTest {
 
         final ProgressEvent<Object, KeyCallbackContext> expectedProgressEvent =
             ProgressEvent.progress(MOCK_MODEL, keyCallbackContext);
+        when(eventualConsistencyHandlerHelper.setRequestType(eq(expectedProgressEvent),eq(false)))
+                .thenReturn(expectedProgressEvent);
         when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(expectedProgressEvent)))
             .thenReturn(expectedProgressEvent);
 

--- a/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
+++ b/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
@@ -46,7 +46,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             new CreatableKeyHandlerHelper<>(ResourceModel.TYPE_NAME, keyApiHelper,
                 eventualConsistencyHandlerHelper, translator);
         this.tagHelper = new TagHelper<>(translator, keyApiHelper, keyHandlerHelper);
-        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
+        this.stabilizeDelay = keyHandlerHelper.BACKOFF_STRATEGY;
     }
 
     public BaseHandlerStd(final ClientBuilder clientBuilder,
@@ -62,7 +62,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         this.eventualConsistencyHandlerHelper = eventualConsistencyHandlerHelper;
         this.keyHandlerHelper = keyHandlerHelper;
         this.tagHelper = new TagHelper<>(translator, keyApiHelper, keyHandlerHelper);
-        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
+        this.stabilizeDelay = keyHandlerHelper.BACKOFF_STRATEGY;
     }
 
     public BaseHandlerStd(final ClientBuilder clientBuilder,
@@ -79,7 +79,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         this.eventualConsistencyHandlerHelper = eventualConsistencyHandlerHelper;
         this.keyHandlerHelper = keyHandlerHelper;
         this.tagHelper = tagHelper;
-        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
+        this.stabilizeDelay = keyHandlerHelper.BACKOFF_STRATEGY;
     }
 
     @VisibleForTesting
@@ -89,7 +89,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                           final EventualConsistencyHandlerHelper<ResourceModel, CallbackContext>
                                   eventualConsistencyHandlerHelper,
                           final CreatableKeyHandlerHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> keyHandlerHelper,
-                          final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper,final Delay stabilizeDelay) {
+                          final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper, final Delay stabilizeDelay) {
         // Allows for mocking helpers in our unit tests
         this.clientBuilder = clientBuilder;
         this.translator = translator;

--- a/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
+++ b/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
@@ -135,9 +135,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return proxy.initiate("kms::update-key-rotation", proxyClient, model, callbackContext)
                 .translateToServiceRequest(translator::enableKeyRotationRequest)
                     .backoffDelay(stabilizeDelay)
-                    .makeServiceCall((enableKeyRotationRequest, proxyClient1) -> {
+                    .makeServiceCall((enableKeyRotationRequest, enableKeyRotationProxyClient) -> {
                         try {
-                            return keyApiHelper.enableKeyRotation((EnableKeyRotationRequest) enableKeyRotationRequest, proxyClient1);
+                            return keyApiHelper.enableKeyRotation((EnableKeyRotationRequest) enableKeyRotationRequest, enableKeyRotationProxyClient);
                         } catch (Exception e) {
                             if (e instanceof CfnNotFoundException) {
                                 throw NotFoundException.builder()

--- a/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
+++ b/key/src/main/java/software/amazon/kms/key/BaseHandlerStd.java
@@ -1,14 +1,19 @@
 package software.amazon.kms.key;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.function.Supplier;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.KeySpec;
 import software.amazon.awssdk.services.kms.model.OriginType;
+import software.amazon.awssdk.services.kms.model.EnableKeyRotationRequest;
+import software.amazon.awssdk.services.kms.model.NotFoundException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnUnauthorizedTaggingOperationException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Delay;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -30,6 +35,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         eventualConsistencyHandlerHelper;
     final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper;
 
+    private final Delay stabilizeDelay;
+
     public BaseHandlerStd() {
         this.clientBuilder = new ClientBuilder();
         this.translator = new Translator();
@@ -39,6 +46,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             new CreatableKeyHandlerHelper<>(ResourceModel.TYPE_NAME, keyApiHelper,
                 eventualConsistencyHandlerHelper, translator);
         this.tagHelper = new TagHelper<>(translator, keyApiHelper, keyHandlerHelper);
+        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
     }
 
     public BaseHandlerStd(final ClientBuilder clientBuilder,
@@ -54,6 +62,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         this.eventualConsistencyHandlerHelper = eventualConsistencyHandlerHelper;
         this.keyHandlerHelper = keyHandlerHelper;
         this.tagHelper = new TagHelper<>(translator, keyApiHelper, keyHandlerHelper);
+        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
     }
 
     public BaseHandlerStd(final ClientBuilder clientBuilder,
@@ -70,7 +79,27 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         this.eventualConsistencyHandlerHelper = eventualConsistencyHandlerHelper;
         this.keyHandlerHelper = keyHandlerHelper;
         this.tagHelper = tagHelper;
+        this.stabilizeDelay= keyHandlerHelper.BACKOFF_STRATEGY;
     }
+
+    @VisibleForTesting
+    public BaseHandlerStd(final ClientBuilder clientBuilder,
+                          final Translator translator,
+                          final KeyApiHelper keyApiHelper,
+                          final EventualConsistencyHandlerHelper<ResourceModel, CallbackContext>
+                                  eventualConsistencyHandlerHelper,
+                          final CreatableKeyHandlerHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> keyHandlerHelper,
+                          final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper,final Delay stabilizeDelay) {
+        // Allows for mocking helpers in our unit tests
+        this.clientBuilder = clientBuilder;
+        this.translator = translator;
+        this.keyApiHelper = keyApiHelper;
+        this.eventualConsistencyHandlerHelper = eventualConsistencyHandlerHelper;
+        this.keyHandlerHelper = keyHandlerHelper;
+        this.tagHelper = tagHelper;
+        this.stabilizeDelay = stabilizeDelay != null ? stabilizeDelay : keyHandlerHelper.BACKOFF_STRATEGY;
+    }
+
 
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -105,7 +134,21 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         if (!wasEnabled && shouldBeEnabled) {
             return proxy.initiate("kms::update-key-rotation", proxyClient, model, callbackContext)
                 .translateToServiceRequest(translator::enableKeyRotationRequest)
-                .makeServiceCall(keyApiHelper::enableKeyRotation)
+                    .backoffDelay(stabilizeDelay)
+                    .makeServiceCall((enableKeyRotationRequest, proxyClient1) -> {
+                        try {
+                            return keyApiHelper.enableKeyRotation((EnableKeyRotationRequest) enableKeyRotationRequest, proxyClient1);
+                        } catch (Exception e) {
+                            if (e instanceof CfnNotFoundException) {
+                                throw NotFoundException.builder()
+                                        .message(e.getMessage())
+                                        .cause(e.getCause())
+                                        .build();
+                            }
+                            throw e;
+                        }
+                    })
+                    .retryErrorFilter((_req, ex, _client, _model, _cb) -> ex instanceof NotFoundException)
                 .progress();
         } else if (wasEnabled && !shouldBeEnabled) {
             return proxy.initiate("kms::update-key-rotation", proxyClient, model, callbackContext)

--- a/key/src/main/java/software/amazon/kms/key/CreateHandler.java
+++ b/key/src/main/java/software/amazon/kms/key/CreateHandler.java
@@ -41,9 +41,9 @@ public class CreateHandler extends BaseHandlerStd {
                          final EventualConsistencyHandlerHelper<ResourceModel, CallbackContext>
                                  eventualConsistencyHandlerHelper,
                          final CreatableKeyHandlerHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> keyHandlerHelper,
-                         final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper,final Delay stabilizeDelay) {
+                         final TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper, final Delay stabilizeDelay) {
         super(clientBuilder, translator, keyApiHelper, eventualConsistencyHandlerHelper,
-                keyHandlerHelper, tagHelper,stabilizeDelay);
+                keyHandlerHelper, tagHelper, stabilizeDelay);
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -62,7 +62,7 @@ public class CreateHandler extends BaseHandlerStd {
                 callbackContext))
             .then(progress -> keyHandlerHelper
                 .disableKeyIfNecessary(proxy, proxyClient, null, model, callbackContext))
-                .then(progress -> eventualConsistencyHandlerHelper.setRequestType(progress,false))
+                .then(progress -> eventualConsistencyHandlerHelper.setRequestType(progress, false))
             // Final propagation to make sure all updates are reflected
             .then(eventualConsistencyHandlerHelper::waitForChangesToPropagate)
             .then(progress -> ProgressEvent.defaultSuccessHandler(unsetWriteOnly(model)));

--- a/key/src/test/java/software/amazon/kms/key/CreateHandlerTest.java
+++ b/key/src/test/java/software/amazon/kms/key/CreateHandlerTest.java
@@ -5,11 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 import com.google.common.collect.ImmutableSet;
@@ -27,10 +23,9 @@ import software.amazon.awssdk.services.kms.model.EnableKeyRotationResponse;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import software.amazon.awssdk.services.kms.model.OriginType;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.delay.CappedExponential;
 import software.amazon.kms.common.ClientBuilder;
 import software.amazon.kms.common.CreatableKeyHandlerHelper;
 import software.amazon.kms.common.CreatableKeyTranslator;
@@ -106,11 +101,19 @@ public class CreateHandlerTest {
     private CallbackContext callbackContext;
     private TagHelper<ResourceModel, CallbackContext, CreatableKeyTranslator<ResourceModel>> tagHelper;
 
+    Delay BACKOFF_STRATEGY =
+            CappedExponential.of()
+                    .minDelay(Duration.ofSeconds(1))
+                    .maxDelay(Duration.ofSeconds(2))
+                    .powerBy(1.3)
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+
     @BeforeEach
     public void setup() {
         tagHelper = new TagHelper<>(translator, keyApiHelper, keyHandlerHelper);
         handler = new CreateHandler(clientBuilder, translator, keyApiHelper,
-                eventualConsistencyHandlerHelper, keyHandlerHelper, tagHelper);
+                eventualConsistencyHandlerHelper, keyHandlerHelper, tagHelper, BACKOFF_STRATEGY);
         proxy = spy(
             new AmazonWebServicesClientProxy(TestConstants.LOGGER, TestConstants.MOCK_CREDENTIALS,
                 () -> Duration.ofSeconds(600).toMillis()));
@@ -139,6 +142,8 @@ public class CreateHandlerTest {
             .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
                 eq(KEY_MODEL_WITH_DEFAULTS_SET),
                 eq(callbackContext))).thenReturn(inProgressEvent);
+        when(eventualConsistencyHandlerHelper.setRequestType(eq(inProgressEvent),eq(false)))
+                .thenReturn(inProgressEvent);
         when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
             .thenReturn(inProgressEvent);
 
@@ -166,6 +171,219 @@ public class CreateHandlerTest {
         verify(keyHandlerHelper).disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
             eq(KEY_MODEL_WITH_DEFAULTS_SET), eq(callbackContext));
         verify(eventualConsistencyHandlerHelper).waitForChangesToPropagate(eq(inProgressEvent));
+
+        // We shouldn't make any other calls
+        verifyNoMoreInteractions(keyApiHelper);
+        verifyZeroInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+    @Test
+    public void handleRequest_SimpleSuccess_RetryEnableKeyRotation() {
+
+        // Mock out our rotation status update
+        final EnableKeyRotationResponse enableKeyRotationResponse =
+                EnableKeyRotationResponse.builder().build();
+        when(
+                keyApiHelper
+                        .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient))).thenThrow(new CfnNotFoundException("AWS::KMS::Key", "keyId"))
+                .thenReturn(enableKeyRotationResponse);
+
+        // Mock our create key call, disable key call, and final propagation
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+                ProgressEvent.progress(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext);
+        when(keyHandlerHelper
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext),
+                        eq(TestConstants.TAGS))).thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
+                        eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext))).thenReturn(inProgressEvent);
+        when(eventualConsistencyHandlerHelper.setRequestType(eq(inProgressEvent), eq(false)))
+                .thenReturn(inProgressEvent);
+        when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
+                .thenReturn(inProgressEvent);
+
+        // Setup our request
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(KEY_MODEL)
+                        .desiredResourceTags(TestConstants.TAGS)
+                        .build();
+
+        // Execute the create handler and make sure it returns the expected results
+
+        assertThat(handler
+                .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER))
+                .isEqualTo(ProgressEvent.defaultSuccessHandler(KEY_MODEL_REDACTED));
+
+
+        // Make sure we enabled rotation
+        verify(keyApiHelper, times(2))
+                .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
+
+        // Make sure we called our helpers to create the key, disable the key if needed,
+        // and to complete the final propagation
+        verify(keyHandlerHelper)
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext), eq(TestConstants.TAGS));
+        verify(keyHandlerHelper).disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
+                eq(KEY_MODEL_WITH_DEFAULTS_SET), eq(callbackContext));
+        verify(eventualConsistencyHandlerHelper).waitForChangesToPropagate(eq(inProgressEvent));
+
+        // We shouldn't make any other calls
+        verifyNoMoreInteractions(keyApiHelper);
+        verifyZeroInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+
+    @Test
+    public void handleRequest_FailedEventualConsistency_EnableKeyRotation() {
+
+        // Mock out our rotation status update
+        final EnableKeyRotationResponse enableKeyRotationResponse =
+                EnableKeyRotationResponse.builder().build();
+        when(
+                keyApiHelper
+                        .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient))).thenThrow(new CfnNotFoundException("AWS::KMS::Key","keyId"));
+
+        // Mock our create key call, disable key call, and final propagation
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+                ProgressEvent.progress(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext);
+        when(keyHandlerHelper
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext),
+                        eq(TestConstants.TAGS))).thenReturn(inProgressEvent);
+
+        // Setup our request
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(KEY_MODEL)
+                        .desiredResourceTags(TestConstants.TAGS)
+                        .build();
+
+        // Execute the create handler and make sure it returns the expected results
+        assertThat(handler
+                .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER))
+                .isEqualTo(ProgressEvent.failed(KEY_MODEL,callbackContext, HandlerErrorCode.NotStabilized,"Exceeded attempts to wait"));
+
+
+        // Make sure we enabled rotation
+        verify(keyApiHelper,atLeast(1))
+                .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
+
+        // Make sure we called our helpers to create the key, disable the key if needed,
+        // and to complete the final propagation
+        verify(keyHandlerHelper)
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext), eq(TestConstants.TAGS));
+
+        // We shouldn't make any other calls
+        verifyNoMoreInteractions(keyApiHelper);
+        verifyZeroInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+
+    @Test
+    public void handleRequest_Failed_EnableKeyRotation() {
+
+        // Mock out our rotation status update
+        final EnableKeyRotationResponse enableKeyRotationResponse =
+                EnableKeyRotationResponse.builder().build();
+        when(
+                keyApiHelper
+                        .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient))).thenThrow(new CfnInvalidRequestException("AWS::KMS::Key"));
+
+        // Mock our create key call, disable key call, and final propagation
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+                ProgressEvent.progress(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext);
+        when(keyHandlerHelper
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext),
+                        eq(TestConstants.TAGS))).thenReturn(inProgressEvent);
+
+        // Setup our request
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(KEY_MODEL)
+                        .desiredResourceTags(TestConstants.TAGS)
+                        .build();
+
+        // Execute the create handler and make sure it returns the expected results
+        try{
+            handler
+                    .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER);
+        }
+        catch(Exception e){
+            System.out.println("Exception is "+e);
+            assertThat( e instanceof CfnInvalidRequestException).isTrue();
+        }
+
+        // Make sure we enabled rotation
+        verify(keyApiHelper,atLeast(1))
+                .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
+
+        // Make sure we called our helpers to create the key, disable the key if needed,
+        // and to complete the final propagation
+        verify(keyHandlerHelper)
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext), eq(TestConstants.TAGS));
+
+        // We shouldn't make any other calls
+        verifyNoMoreInteractions(keyApiHelper);
+        verifyZeroInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+    @Test
+    public void handleRequest_FailedDisableKey() {
+
+        // Mock out our rotation status update
+        final EnableKeyRotationResponse enableKeyRotationResponse =
+                EnableKeyRotationResponse.builder().build();
+        when(
+                keyApiHelper
+                        .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient))).thenThrow(CfnNotFoundException.class)
+                .thenReturn(enableKeyRotationResponse);
+
+        // Mock our create key call, disable key call, and final propagation
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+                ProgressEvent.progress(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext);
+
+        final ProgressEvent<ResourceModel, CallbackContext> failedProgressEvent =
+                ProgressEvent.failed(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext,HandlerErrorCode.NotStabilized,"Key Id not found");
+        when(keyHandlerHelper
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext),
+                        eq(TestConstants.TAGS))).thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
+                        eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext))).thenReturn(failedProgressEvent);
+
+        // Setup our request
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(KEY_MODEL)
+                        .desiredResourceTags(TestConstants.TAGS)
+                        .build();
+
+        // Execute the create handler and make sure it returns the expected results
+        final ProgressEvent<ResourceModel, CallbackContext> response=handler
+                .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+
+        // Make sure we enabled rotation
+        verify(keyApiHelper,times(2))
+                .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
+
+        // Make sure we called our helpers to create the key, disable the key if needed,
+        // and to complete the final propagation
+        verify(keyHandlerHelper)
+                .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
+                        eq(callbackContext), eq(TestConstants.TAGS));
+        verify(keyHandlerHelper).disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
+                eq(KEY_MODEL_WITH_DEFAULTS_SET), eq(callbackContext));
 
         // We shouldn't make any other calls
         verifyNoMoreInteractions(keyApiHelper);
@@ -214,6 +432,8 @@ public class CreateHandlerTest {
                 .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), isNull(),
                         eq(KEY_MODEL_EXTERNAL_ROTATION_DISABLED),
                         eq(callbackContext))).thenReturn(inProgressEvent);
+        when(eventualConsistencyHandlerHelper.setRequestType(eq(inProgressEvent),eq(false)))
+                .thenReturn(inProgressEvent);
         when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
                 .thenReturn(inProgressEvent);
 

--- a/key/src/test/java/software/amazon/kms/key/CreateHandlerTest.java
+++ b/key/src/test/java/software/amazon/kms/key/CreateHandlerTest.java
@@ -189,6 +189,7 @@ public class CreateHandlerTest {
         verifyZeroInteractions(keyHandlerHelper);
         verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
     }
+
     @Test
     public void handleRequest_SimpleSuccess_RetryEnableKeyRotation() {
 
@@ -256,7 +257,7 @@ public class CreateHandlerTest {
                 EnableKeyRotationResponse.builder().build();
         when(keyApiHelper
                 .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient)))
-                .thenThrow(new CfnNotFoundException("AWS::KMS::Key","keyId"));
+                .thenThrow(new CfnNotFoundException("AWS::KMS::Key", "keyId"));
 
         // Mock our create key call, disable key call, and final propagation
         final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
@@ -276,11 +277,11 @@ public class CreateHandlerTest {
         // Execute the create handler and make sure it returns the expected results
         assertThat(handler
                 .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER))
-                .isEqualTo(ProgressEvent.failed(KEY_MODEL,callbackContext, HandlerErrorCode.NotStabilized,
+                .isEqualTo(ProgressEvent.failed(KEY_MODEL, callbackContext, HandlerErrorCode.NotStabilized,
                         "Exceeded attempts to wait"));
 
         // Make sure we enabled rotation
-        verify(keyApiHelper,atLeast(1))
+        verify(keyApiHelper, atLeast(1))
                 .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
 
         // Make sure we called our helpers to create the key, disable the key if needed,
@@ -321,16 +322,15 @@ public class CreateHandlerTest {
                         .build();
 
         // Execute the create handler and make sure it returns the expected results
-        try{
+        try {
             handler
                     .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER);
-        }
-        catch(Exception e){
-            assertThat( e instanceof CfnInvalidRequestException).isTrue();
+        } catch (Exception e) {
+            assertThat(e instanceof CfnInvalidRequestException).isTrue();
         }
 
         // Make sure we enabled rotation
-        verify(keyApiHelper,atLeast(1))
+        verify(keyApiHelper, atLeast(1))
                 .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
 
         // Make sure we called our helpers to create the key, disable the key if needed,
@@ -344,6 +344,7 @@ public class CreateHandlerTest {
         verifyZeroInteractions(keyHandlerHelper);
         verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
     }
+
     @Test
     public void handleRequest_FailedDisableKey() {
 
@@ -360,7 +361,7 @@ public class CreateHandlerTest {
                 ProgressEvent.progress(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext);
 
         final ProgressEvent<ResourceModel, CallbackContext> failedProgressEvent =
-                ProgressEvent.failed(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext,HandlerErrorCode.NotStabilized,"Key Id not found");
+                ProgressEvent.failed(KEY_MODEL_WITH_DEFAULTS_SET, callbackContext, HandlerErrorCode.NotStabilized, "Key Id not found");
         when(keyHandlerHelper
                 .createKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_WITH_DEFAULTS_SET),
                         eq(callbackContext),
@@ -378,13 +379,13 @@ public class CreateHandlerTest {
                         .build();
 
         // Execute the create handler and make sure it returns the expected results
-        final ProgressEvent<ResourceModel, CallbackContext> response=handler
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler
                 .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER);
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
 
         // Make sure we enabled rotation
-        verify(keyApiHelper,times(2))
+        verify(keyApiHelper, times(2))
                 .enableKeyRotation(any(EnableKeyRotationRequest.class), eq(proxyKmsClient));
 
         // Make sure we called our helpers to create the key, disable the key if needed,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Create Handler
 1.) createKey
 2.) wait for eventual consistency (60 sec sleep) -> Remove it
 3.) api call to updateKeyRotation → Try this API call with Exponential Retry. If API throws NotFound error (which means changes have not propagated) retry API call with exponential retry strategy
 4.) api call to disableKey → Try this API call with Exponential Retry. If API throws NotFound error (which means changes have not propagated) retry API with exponential retry
 5.) wait for eventual consistency - 15 sec sleep - Update eventual consistency delay to 15 secs. Have final wait to ensure changes have propagated 
 6.) Return success

DeleteHandler
1.) deleteKey
2.) Wait for eventual consistency -> 60 sec to 15 secs 

Testing
Unit Test
Integration Test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
