### PR TITLE
Remove KeyPolicy default in aws-kms-key.json

### DIFF
--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -47,8 +47,7 @@
       "type": [
         "object",
         "string"
-      ],
-      "default": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}"
+      ]
     },
     "KeyUsage": {
       "description": "Determines the cryptographic operations for which you can use the AWS KMS key. The default value is ENCRYPT_DECRYPT. This property is required only for asymmetric AWS KMS keys. You can't change the KeyUsage value after the AWS KMS key is created.",


### PR DESCRIPTION
## Description of changes

The default KeyPolicy in aws-kms-key.json is not a valid policy and is sometimes being inserted as a default into templates updates that specify no KeyPolicy property. This change removes the default from aws-kms-key.json. It's presence is unnecessary since there is existing documentation of the intended KeyPolicy default behavior.

## Testing

Ran the following series of steps in ca-west-1 and eu-west-1 without getting any errors

```sh
cat > awskmskey-without-props <<HERE
Resources:
  KeyResource:
    Type: AWS::KMS::Key
HERE

aws --region $REGION cloudformation create-stack --stack-name P127469077-repro --template-body file://awskmskey-without-props
```

```sh
cat > awskmskey-with-policy <<HERE
Resources:
  KeyResource:
    Type: AWS::KMS::Key
    Properties:
      KeyPolicy:
        Version: 2012-10-17
        Id: key-default-1
        Statement:
          - Sid: EXPLICITLY DEFINED POLICY
            Effect: Allow
            Principal:
              AWS: !Ref 'AWS::AccountId'
            Action: 'kms:*'
            Resource: '*'
HERE

aws --region $REGION cloudformation update-stack --stack-name P127469077-repro --template-body file://awskmskey-with-policy
```

```
aws --region $REGION cloudformation update-stack --stack-name P127469077-repro --template-body file://awskmskey-without-props
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
