### PR TITLE
Revert "Remove KeyPolicy default in aws-kms-key.json (#63)" 

### DIFF
--- a/common/src/main/java/software/amazon/kms/common/KeyTranslator.java
+++ b/common/src/main/java/software/amazon/kms/common/KeyTranslator.java
@@ -40,7 +40,7 @@ public abstract class KeyTranslator<M> {
     protected static final String DEFAULT_POLICY_NAME = "default";
     protected static final int LIST_KEYS_PAGE_SIZE = 50;
 
-    /** This is the default key policy from aws-kme-key.json */
+    /** This is the default key policy from aws-kms-key.json */
     public static String DEFAULT_KEY_POLICY_FROM_JSON = "{" +
             "\n" +
             "    \"Version\": \"2012-10-17\",\n" +
@@ -192,7 +192,7 @@ public abstract class KeyTranslator<M> {
         final String policyString;
         if (policy instanceof Map) {
             try {
-                policyString = new ObjectMapper().writeValueAsString(policy);
+                policyString = objectMapper.writeValueAsString(policy);
             } catch (final JsonProcessingException e) {
                 throw new TerminalException(e);
             }

--- a/common/src/test/java/software/amazon/kms/common/KeyTranslatorTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyTranslatorTest.java
@@ -43,6 +43,13 @@ public class KeyTranslatorTest {
     }
 
     @Test
+    public void testTranslatePolicyInputObjectDefaultKeyPolicyFromJson() {
+        assertThat(keyTranslator
+            .translatePolicyInput(TestConstants.DEFAULT_KEY_POLICY_FROM_JSON))
+            .isEqualTo("");
+    }
+
+    @Test
     public void testTranslatePolicyInputJsonProcessingException() throws JsonProcessingException {
         final ObjectMapper mockMapper = mock(ObjectMapper.class);
         when(mockMapper.writeValueAsString(eq(TestConstants.DESERIALIZED_KEY_POLICY)))
@@ -51,6 +58,20 @@ public class KeyTranslatorTest {
 
         try {
             mockKeyTranslator.translatePolicyInput(TestConstants.DESERIALIZED_KEY_POLICY);
+        } catch (Exception e) {
+            assertThat(e instanceof TerminalException);
+        }
+    }
+
+    @Test
+    public void testTranslatePolicyInputWithJsonProcessingDefaultKeyPolicyJson() throws JsonProcessingException {
+        final ObjectMapper mockMapper = mock(ObjectMapper.class);
+        when(mockMapper.writeValueAsString(eq(TestConstants.DEFAULT_KEY_POLICY_FROM_JSON)))
+                .thenThrow(JsonProcessingException.class);
+        final MockKeyTranslator mockKeyTranslator = new MockKeyTranslator(mockMapper);
+
+        try {
+            mockKeyTranslator.translatePolicyInput(TestConstants.DEFAULT_KEY_POLICY_FROM_JSON);
         } catch (Exception e) {
             assertThat(e instanceof TerminalException);
         }

--- a/common/src/test/java/software/amazon/kms/common/KeyTranslatorTest.java
+++ b/common/src/test/java/software/amazon/kms/common/KeyTranslatorTest.java
@@ -49,8 +49,11 @@ public class KeyTranslatorTest {
             .thenThrow(JsonProcessingException.class);
         final MockKeyTranslator mockKeyTranslator = new MockKeyTranslator(mockMapper);
 
-        assertThatExceptionOfType(TerminalException.class).isThrownBy(
-            () -> mockKeyTranslator.translatePolicyInput(TestConstants.DESERIALIZED_KEY_POLICY));
+        try {
+            mockKeyTranslator.translatePolicyInput(TestConstants.DESERIALIZED_KEY_POLICY);
+        } catch (Exception e) {
+            assertThat(e instanceof TerminalException);
+        }
     }
 
     @Test

--- a/common/src/test/java/software/amazon/kms/common/TestConstants.java
+++ b/common/src/test/java/software/amazon/kms/common/TestConstants.java
@@ -46,6 +46,23 @@ public class TestConstants {
             "    ]\n" +
             "}";
 
+    public static String DEFAULT_KEY_POLICY_FROM_JSON = "{" +
+            "\n" +
+            "    \"Version\": \"2012-10-17\",\n" +
+            "    \"Id\": \"key-default\",\n" +
+            "    \"Statement\": [\n" +
+            "        {\n" +
+            "            \"Sid\": \"Enable IAM User Permissions\",\n" +
+            "            \"Effect\": \"Allow\",\n" +
+            "            \"Principal\": {\n" +
+            "                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n" +
+            "            },\n" +
+            "            \"Action\": \"kms:*\",\n" +
+            "            \"Resource\": \"*\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+
     // Tag related test constants
     public static final Map<String, String> TAGS = new ImmutableMap.Builder<String, String>()
         .put("Key1", "Value1")

--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -145,7 +145,8 @@
     "taggable": true,
     "tagOnCreate": true,
     "tagUpdatable": true,
-    "cloudFormationSystemTags": false
+    "cloudFormationSystemTags": false,
+    "tagProperty": "/properties/Tags"
   },
   "handlers": {
     "create": {

--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -47,7 +47,8 @@
       "type": [
         "object",
         "string"
-      ]
+      ],
+      "default": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}"
     },
     "KeyUsage": {
       "description": "Determines the cryptographic operations for which you can use the AWS KMS key. The default value is ENCRYPT_DECRYPT. This property is required only for asymmetric AWS KMS keys. You can't change the KeyUsage value after the AWS KMS key is created.",

--- a/key/src/main/java/software/amazon/kms/key/ModelAdapter.java
+++ b/key/src/main/java/software/amazon/kms/key/ModelAdapter.java
@@ -1,6 +1,7 @@
 package software.amazon.kms.key;
 
 import java.util.Map;
+import java.util.Objects;
 
 import com.amazonaws.util.StringUtils;
 
@@ -11,6 +12,8 @@ import software.amazon.awssdk.services.kms.model.KeySpec;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import software.amazon.awssdk.services.kms.model.OriginType;
 import software.amazon.cloudformation.exceptions.TerminalException;
+
+import static software.amazon.kms.common.KeyTranslator.DEFAULT_KEY_POLICY_FROM_JSON;
 
 public class ModelAdapter {
     private static final String DEFAULT_DESCRIPTION = "";
@@ -81,14 +84,17 @@ public class ModelAdapter {
     public static String translatePolicyInput(final Object policy) {
         // Key Policy can be specified as either a string or an object (JSON)
         // Convert it to a string, so it can be used in our API calls
+        final String policyString;
         if (policy instanceof Map) {
             try {
-                return new ObjectMapper().writeValueAsString(policy);
+                policyString = new ObjectMapper().writeValueAsString(policy);
             } catch (final JsonProcessingException e) {
                 throw new TerminalException(e);
             }
+        } else {
+            policyString = (String) policy;
         }
-        return (String) policy;
+        return (Objects.equals(policyString, DEFAULT_KEY_POLICY_FROM_JSON)) ? "" : policyString;
     }
 
     /**

--- a/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
+++ b/key/src/test/java/software/amazon/kms/key/UpdateHandlerTest.java
@@ -92,8 +92,26 @@ public class UpdateHandlerTest {
                 .key("Key")
                 .value("Value")
                 .build()));
+
+    private static final ResourceModel.ResourceModelBuilder KEY_MODEL_DEFAULT_KEY_POLICY_BUILDER =
+        ResourceModel.builder()
+            .keyId("mock-key-id")
+            .arn("mock-arn")
+            .description("mock-description")
+            .enabled(true)
+            .enableKeyRotation(false)
+            .multiRegion(false)
+            .origin(TestConstants.KEY_ORIGIN)
+            .keyUsage(KeyUsageType.ENCRYPT_DECRYPT.toString())
+            .keySpec(KeySpec.SYMMETRIC_DEFAULT.toString())
+            .keyPolicy(TestConstants.DEFAULT_KEY_POLICY_FROM_JSON)
+            .tags(ImmutableSet.of(Tag.builder()
+                .key("Key")
+                .value("Value")
+                .build()));
     private static final ResourceModel KEY_MODEL_REDACTED = KEY_MODEL_BUILDER.build();
     private static final ResourceModel KEY_MODEL_REDACTED_DEFAULT_POLICY = KEY_MODEL_DEFAULT_POLICY_BUILDER.build();
+    private static final ResourceModel KEY_MODEL_DEFAULT_POLICY = KEY_MODEL_DEFAULT_KEY_POLICY_BUILDER.build();
     private static final ResourceModel KEY_MODEL = KEY_MODEL_BUILDER
         .enableKeyRotation(null)
         .pendingWindowInDays(7)
@@ -330,6 +348,88 @@ public class UpdateHandlerTest {
         verifyNoMoreInteractions(keyHandlerHelper);
         verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
     }
+
+    @Test
+    public void handleRequest_SimpleSuccessWithDefaultKeyPolicy() {
+        // Mock out delegation to our helpers and make them return an IN_PROGRESS event
+        final ProgressEvent<ResourceModel, CallbackContext> inProgressEvent =
+                ProgressEvent.progress(KEY_MODEL_DEFAULT_POLICY, callbackContext);
+        final TagResourceResponse tagResourceResponse = TagResourceResponse.builder().build();
+        final UntagResourceResponse untagResourceResponse = UntagResourceResponse.builder().build();
+        when(keyHandlerHelper
+                .describeKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext),
+                        eq(false)))
+                .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .enableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext), eq(true)))
+                .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext)))
+                .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .updateKeyDescription(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext)))
+                .thenReturn(inProgressEvent);
+        when(keyHandlerHelper
+                .updateKeyPolicy(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(KEY_MODEL_DEFAULT_POLICY),
+                        eq(callbackContext)))
+                .thenReturn(inProgressEvent);
+        when(keyApiHelper.tagResource(any(TagResourceRequest.class), eq(proxyKmsClient)))
+                .thenReturn(tagResourceResponse);
+        when(keyApiHelper.untagResource(any(UntagResourceRequest.class), eq(proxyKmsClient)))
+                .thenReturn(untagResourceResponse);
+        when(keyHandlerHelper.retrieveResourceTags(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext),
+                eq(false))).thenReturn(inProgressEvent);
+        when(eventualConsistencyHandlerHelper.waitForChangesToPropagate(eq(inProgressEvent)))
+                .thenReturn(inProgressEvent);
+
+        // Set up our request
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .awsPartition(TestConstants.AWS_PARTITION)
+                        .awsAccountId(TestConstants.ACCOUNT_ID)
+                        .previousResourceState(KEY_MODEL)
+                        .desiredResourceState(KEY_MODEL_DEFAULT_POLICY)
+                        .desiredResourceTags(TestConstants.TAGS)
+                        .previousResourceTags(TestConstants.PREVIOUS_TAGS)
+                        .build();
+
+        // Execute the update handler and make sure it returns the expected results
+        assertThat(handler
+                .handleRequest(proxy, request, callbackContext, proxyKmsClient, TestConstants.LOGGER))
+                .isEqualTo(ProgressEvent.defaultSuccessHandler(KEY_MODEL_REDACTED_DEFAULT_POLICY));
+
+        // Make sure we called our helpers with the correct parameters and did the final propagation
+        verify(keyHandlerHelper)
+                .describeKey(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext),
+                        eq(false));
+        verify(keyHandlerHelper)
+                .enableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext), eq(true));
+        verify(keyHandlerHelper)
+                .disableKeyIfNecessary(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext));
+        verify(keyHandlerHelper)
+                .updateKeyDescription(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL),
+                        eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext));
+        verify(keyHandlerHelper)
+                .updateKeyPolicy(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL), eq(KEY_MODEL_DEFAULT_POLICY),
+                        eq(callbackContext));
+        verify(keyHandlerHelper)
+                .retrieveResourceTags(eq(proxy), eq(proxyKmsClient), eq(KEY_MODEL_DEFAULT_POLICY), eq(callbackContext), eq(false));
+        verify(keyApiHelper)
+                .tagResource(any(TagResourceRequest.class), eq(proxyKmsClient));
+        verify(keyApiHelper).untagResource(any(UntagResourceRequest.class), eq(proxyKmsClient));
+        verify(eventualConsistencyHandlerHelper).waitForChangesToPropagate(eq(inProgressEvent));
+
+        // We shouldn't call anything else
+        verifyZeroInteractions(keyApiHelper);
+        verifyNoMoreInteractions(keyHandlerHelper);
+        verifyNoMoreInteractions(eventualConsistencyHandlerHelper);
+    }
+
 
     @Test
     public void handleRequest_TagUpdateAccessDenied() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request reverts commit 6cd611742decb007ffa766b9b49e9c0a0f239871 as it is causing contract tests failures with https://github.com/aws-cloudformation/resource-schema-guard-rail/blob/main/docs/BREAKING_CHANGE.md PR001

Updated `tagProperty` in aws-kms-key.json to fix https://github.com/aws-cloudformation/resource-schema-guard-rail/blob/main/docs/BASIC_LINTING.md TAG010

This also adds logic to ignore the default key policy from aws-kms-key.json as it is causing Integration test failure. 
