### PR TITLE
Add support for ML-DSA

### DIFF
--- a/key/aws-kms-key.json
+++ b/key/aws-kms-key.json
@@ -87,7 +87,10 @@
         "HMAC_256",
         "HMAC_384",
         "HMAC_512",
-        "SM2"
+        "SM2",
+        "ML_DSA_44",
+        "ML_DSA_65",
+        "ML_DSA_87"
       ]
     },
     "MultiRegion": {

--- a/key/docs/README.md
+++ b/key/docs/README.md
@@ -147,7 +147,7 @@ _Required_: No
 
 _Type_: String
 
-_Allowed Values_: <code>SYMMETRIC_DEFAULT</code> | <code>RSA_2048</code> | <code>RSA_3072</code> | <code>RSA_4096</code> | <code>ECC_NIST_P256</code> | <code>ECC_NIST_P384</code> | <code>ECC_NIST_P521</code> | <code>ECC_SECG_P256K1</code> | <code>HMAC_224</code> | <code>HMAC_256</code> | <code>HMAC_384</code> | <code>HMAC_512</code> | <code>SM2</code>
+_Allowed Values_: <code>SYMMETRIC_DEFAULT</code> | <code>RSA_2048</code> | <code>RSA_3072</code> | <code>RSA_4096</code> | <code>ECC_NIST_P256</code> | <code>ECC_NIST_P384</code> | <code>ECC_NIST_P521</code> | <code>ECC_SECG_P256K1</code> | <code>HMAC_224</code> | <code>HMAC_256</code> | <code>HMAC_384</code> | <code>HMAC_512</code> | <code>SM2</code> | <code>ML_DSA_44</code> | <code>ML_DSA_65</code> | <code>ML_DSA_87</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
Added ML-DSA Support in CloudFormation. With ML-DSA KMS extended the support for three new KeySpec's i.e., ML_DSA_44, ML_DSA_65 and ML_DSA_87
